### PR TITLE
esm 에서 동작하기 위한 dependency alias 적용

### DIFF
--- a/.changeset/itchy-shirts-chew.md
+++ b/.changeset/itchy-shirts-chew.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/nurl": patch
+---
+
+esm 에서 동작하기 위한 dependency alias 적용 https://github.com/NaverPayDev/nurl/pull/26

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.2",
     "description": "URL build library",
     "main": "./dist/cjs/index.js",
-    "module": "./dist/module/index.js",
+    "module": "./dist/esm/index.mjs",
     "exports": {
         ".": {
             "import": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "license": "MIT",
     "dependencies": {
         "@babel/runtime-corejs3": "^7.25.6",
-        "punycode": "^2.3.1"
+        "npm-punycode": "npm:punycode@^2.3.1"
     },
     "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.25.4",
@@ -62,7 +62,7 @@
         "@naverpay/markdown-lint": "^0.0.3",
         "@naverpay/prettier-config": "^1.0.0",
         "@rollup/plugin-babel": "^6.0.4",
-        "@types/punycode": "^2.1.4",
+        "@types/npm-punycode": "npm:@types/punycode@^2.1.4",
         "browserslist-to-esbuild": "^2.1.1",
         "tsup": "^8.2.4",
         "typescript": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ importers:
       '@babel/runtime-corejs3':
         specifier: ^7.25.6
         version: 7.25.6
-      punycode:
-        specifier: ^2.3.1
-        version: 2.3.1
+      npm-punycode:
+        specifier: npm:punycode@^2.3.1
+        version: punycode@2.3.1
     devDependencies:
       '@babel/plugin-transform-runtime':
         specifier: ^7.25.4
@@ -42,9 +42,9 @@ importers:
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.25.2)(@types/babel__core@7.20.5)(rollup@4.21.2)
-      '@types/punycode':
-        specifier: ^2.1.4
-        version: 2.1.4
+      '@types/npm-punycode':
+        specifier: npm:@types/punycode@^2.1.4
+        version: '@types/punycode@2.1.4'
       browserslist-to-esbuild:
         specifier: ^2.1.1
         version: 2.1.1(browserslist@4.23.3)

--- a/src/nurl.ts
+++ b/src/nurl.ts
@@ -1,11 +1,11 @@
 /**
- * Note: The trailing slash in the import path 'punycode/' is intentional.
- * It ensures that this third-party module is used instead of the built-in
+ * Note: We use 'npm-punycode' alias instead of 'punycode/' to properly support dual packages in ESM.
+ * This ensures that this third-party module is used instead of the built-in
  * Node.js 'punycode' module, which has been deprecated since Node.js v7.0.0.
  * @see https://github.com/mathiasbynens/punycode.js#installation
  * @see https://nodejs.org/api/punycode.html for deprecation info
  */
-import {decode, encode} from 'punycode/'
+import {decode, encode} from 'npm-punycode'
 
 import {
     extractPathKey,


### PR DESCRIPTION
cjs 에서는 native 모듈과 충돌을 피하기 위해서 `/` 를 붙였어야 했는데,
esm 에서는 `/` 로 끝나게 되면 디렉토리로 인식해 수정합니다. [`ERR_UNSUPPORTED_DIR_IMPORT`](https://nodejs.org/api/errors.html#err_unsupported_dir_import)
