### PR TITLE
punycode dual packages 를 위해 exports patch

### DIFF
--- a/.changeset/spicy-jokes-attack.md
+++ b/.changeset/spicy-jokes-attack.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/nurl": patch
+---
+
+punycode dual packages 를 위해 exports patch

--- a/package.json
+++ b/package.json
@@ -69,5 +69,10 @@
         "vite": "^5.4.3",
         "vitest": "^2.0.5"
     },
-    "packageManager": "pnpm@9.1.1"
+    "packageManager": "pnpm@9.1.1",
+    "pnpm": {
+        "patchedDependencies": {
+            "punycode@2.3.1": "patches/punycode@2.3.1.patch"
+        }
+    }
 }

--- a/patches/punycode@2.3.1.patch
+++ b/patches/punycode@2.3.1.patch
@@ -1,0 +1,36 @@
+diff --git a/package.json b/package.json
+index b8b76fc76c2162104f066c6f2330a7cacdee4a72..717b358f589e7b37db90a5991c077371dab8756d 100644
+--- a/package.json
++++ b/package.json
+@@ -3,9 +3,19 @@
+   "version": "2.3.1",
+   "description": "A robust Punycode converter that fully complies to RFC 3492 and RFC 5891, and works on nearly all JavaScript platforms.",
+   "homepage": "https://mths.be/punycode",
+-  "main": "punycode.js",
+-  "jsnext:main": "punycode.es6.js",
+-  "module": "punycode.es6.js",
++  "main": "punycode.cjs",
++  "jsnext:main": "punycode.es6.mjs",
++  "module": "punycode.es6.mjs",
++  "exports": {
++      ".": {
++          "import": {
++              "default": "./punycode.es6.mjs"
++          },
++          "require": {
++              "default": "./punycode.cjs"
++          }
++      }
++  },
+   "engines": {
+     "node": ">=6"
+   },
+diff --git a/punycode.js b/punycode.cjs
+similarity index 100%
+rename from punycode.js
+rename to punycode.cjs
+diff --git a/punycode.es6.js b/punycode.es6.mjs
+similarity index 100%
+rename from punycode.es6.js
+rename to punycode.es6.mjs
+index dadece25b35f595d717ec52adfc94d23d3b1edda..0000000000000000000000000000000000000000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  punycode@2.3.1:
+    hash: 3chbanumxrxjf27x54awjweob4
+    path: patches/punycode@2.3.1.patch
+
 importers:
 
   .:
@@ -13,7 +18,7 @@ importers:
         version: 7.25.6
       npm-punycode:
         specifier: npm:punycode@^2.3.1
-        version: punycode@2.3.1
+        version: punycode@2.3.1(patch_hash=3chbanumxrxjf27x54awjweob4)
     devDependencies:
       '@babel/plugin-transform-runtime':
         specifier: ^7.25.4
@@ -6563,7 +6568,7 @@ snapshots:
 
   pseudomap@1.0.2: {}
 
-  punycode@2.3.1: {}
+  punycode@2.3.1(patch_hash=3chbanumxrxjf27x54awjweob4): {}
 
   queue-microtask@1.2.3: {}
 
@@ -6928,7 +6933,7 @@ snapshots:
 
   tr46@1.0.1:
     dependencies:
-      punycode: 2.3.1
+      punycode: 2.3.1(patch_hash=3chbanumxrxjf27x54awjweob4)
 
   tree-kill@1.2.2: {}
 
@@ -7049,7 +7054,7 @@ snapshots:
 
   uri-js@4.4.1:
     dependencies:
-      punycode: 2.3.1
+      punycode: 2.3.1(patch_hash=3chbanumxrxjf27x54awjweob4)
 
   vite-node@2.0.5(@types/node@22.0.2)(terser@5.31.3):
     dependencies:


### PR DESCRIPTION
punycode 의 올바른 import를 위해 patch를 적용합니다.

- punycode
  - node module과 충돌이 있어 nodejs 에서는 'punycode/'로 불러와야하는데 esm 에서는 `/`로 끝나면 디렉토리로 인식해 에러 발생
  - exports field로 'punycode/npm' 이런식으로 import 해볼 수 있으나 d.ts를 새롭게 만들어야함
- npm alias 사용
  - punycode 패키지의 module을 해석하지 못하고 cjs 파일을 불러옴
  - exports filed를 추가해 patch ...