### PR TITLE
Add basePath Support to NURL Class with Duplicate Prevention

### DIFF
--- a/.changeset/tiny-yaks-shout.md
+++ b/.changeset/tiny-yaks-shout.md
@@ -1,0 +1,5 @@
+---
+"@naverpay/nurl": patch
+---
+
+Add basePath Support to NURL Class with Duplicate Prevention

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -633,4 +633,57 @@ describe('NURL', () => {
             })
         })
     })
+
+    describe('Base Path Support', () => {
+        test('should prepend basePath when provided in constructor', () => {
+            const nurl = new NURL({
+                baseUrl: 'https://example.com',
+                basePath: '/app',
+                pathname: '/about',
+            })
+            expect(nurl.href).toBe('https://example.com/app/about')
+        })
+
+        test('should not double prepend basePath if pathname already includes it', () => {
+            const nurl = new NURL({
+                baseUrl: 'https://example.com',
+                basePath: '/app',
+                pathname: '/app/about',
+            })
+            expect(nurl.href).toBe('https://example.com/app/about')
+        })
+
+        test('should work with relative URLs', () => {
+            const nurl = new NURL({
+                basePath: '/app',
+                pathname: '/contact',
+            })
+            expect(nurl.href).toBe('/app/contact')
+        })
+
+        test('should update pathname with basePath after instantiation', () => {
+            const nurl = new NURL({baseUrl: 'https://example.com', basePath: '/app'})
+            nurl.pathname = '/features'
+            expect(nurl.href).toBe('https://example.com/app/features')
+        })
+
+        test('should allow using the withBasePath static method', () => {
+            const createNURL = NURL.withBasePath('/app')
+            const url = createNURL('https://example.com')
+            url.pathname = '/docs'
+            expect(url.href).toBe('https://example.com/app/docs')
+        })
+
+        test('withBasePath should handle URLOptions properly', () => {
+            const createNURL = NURL.withBasePath('/app')
+            const url = createNURL({baseUrl: 'https://example.com', pathname: '/team'})
+            expect(url.href).toBe('https://example.com/app/team')
+        })
+
+        test('withBasePath should not double prepend', () => {
+            const createNURL = NURL.withBasePath('/app')
+            const url = createNURL({baseUrl: 'https://example.com', pathname: '/app/help'})
+            expect(url.href).toBe('https://example.com/app/help')
+        })
+    })
 })


### PR DESCRIPTION
## PR

This pull request introduces `basePath` support to the `NURL` class, allowing a specified base path to be automatically prepended to all `pathname` values. This feature helps streamline URL management in Next.js and other environments where a `basePath` is commonly used, eliminating the need to manually prepend it for every URL construction.

## Key Changes

- Added a new `basePath` option to the `URLOptions` interface and integrated it into the `NURL` class constructor.  
- Updated the `pathname` setter to automatically prepend the `basePath` if not already present.  
- Implemented a static factory method, `NURL.withBasePath(basePath)`, which returns a function for creating `NURL` instances with a predefined `basePath`.  
- Ensured that if the `pathname` already includes the `basePath`, it will not be added again (preventing duplicate insertion).  
- Added comprehensive tests to verify `basePath` functionality, including scenarios with relative URLs and dynamic segments.

## Examples

```ts
// Creating a NURL instance with a basePath directly:
const nurl = new NURL({
  baseUrl: 'https://example.com',
  basePath: '/app',
  pathname: '/about',
})
console.log(nurl.href) // 'https://example.com/app/about'

// Using the static factory method for convenience:
const createNURL = NURL.withBasePath('/app')
const url = createNURL('https://example.com')
url.pathname = '/docs'
console.log(url.href) // 'https://example.com/app/docs'

// Ensuring no double prepend:
const url2 = createNURL({ baseUrl: 'https://example.com', pathname: '/app/help' })
console.log(url2.href) // 'https://example.com/app/help', not 'https://example.com/app/app/help'
```

## Question

How do you feel about the current approach to ensure that the `basePath` is not appended multiple times if it is already present in the `pathname`? Are there any alternative methods or improvements you would suggest for handling this logic?