### PR TITLE
query 타입을 확장합니다.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -217,6 +217,7 @@ describe('NURL', () => {
                 const nurl = new NURL({
                     baseUrl: 'https://example.com',
                     pathname: '/path',
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     query: {valid: 'yes', invalid: {}, anotherInvalid: []} as any,
                 })
 

--- a/src/nurl.ts
+++ b/src/nurl.ts
@@ -6,6 +6,8 @@ import {
     isDynamicPath,
     refinePathnameWithQuery,
     refineQueryWithPathname,
+    convertQueryToArray,
+    Query,
 } from './utils'
 
 interface URLOptions
@@ -25,7 +27,7 @@ interface URLOptions
         >
     > {
     baseUrl?: string
-    query?: Record<string, string>
+    query?: Query
     basePath?: string
 }
 
@@ -97,7 +99,7 @@ export default class NURL implements URL {
             if (input.query) {
                 const refinedQuery = refineQueryWithPathname(input.pathname ?? '', input.query)
                 if (Object.keys(refinedQuery).length > 0) {
-                    this.search = new URLSearchParams(refinedQuery).toString()
+                    this.search = new URLSearchParams(convertQueryToArray(refinedQuery)).toString()
                 }
             }
             this.updateHref()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,6 +39,12 @@ export function refinePathnameWithQuery(pathname: string, query: Query): string 
 export function refineQueryWithPathname(pathname: string, query: Query): Query {
     return getDynamicPaths(pathname).reduce((acc, path) => {
         const pathKey = extractPathKey(path)
+
+        const queryValue = acc[pathKey]
+        if (typeof queryValue !== 'string') {
+            return acc
+        }
+
         const {[pathKey]: _, ...remainingQuery} = acc
         return remainingQuery
     }, query)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 const DYNAMIC_PATH_COLON_REGEXP = /^:/
 const DYNAMIC_PATH_BRACKETS_REGEXP = /^\[.*\]$/
 
+export type Query = Record<string, string | number | boolean | (string | number | boolean)[]>
+
 export function isDynamicPath(path: string) {
     return DYNAMIC_PATH_COLON_REGEXP.test(path) || DYNAMIC_PATH_BRACKETS_REGEXP.test(path)
 }
@@ -16,23 +18,25 @@ export function extractPathKey(path: string): string {
 /**
  * Replaces dynamic paths in the pathname with values from the query
  * @param {string} pathname
- * @param {Record<string, string>} query
+ * @param {Query} query
  * @returns {string} refined pathname
  */
-export function refinePathnameWithQuery(pathname: string, query: Record<string, string>): string {
+export function refinePathnameWithQuery(pathname: string, query: Query): string {
     return getDynamicPaths(pathname).reduce((acc, path) => {
         const pathKey = extractPathKey(path)
-        return query[pathKey] ? acc.replace(path, query[pathKey]) : acc
+
+        const queryValue = query[pathKey]
+        return queryValue && typeof queryValue === 'string' ? acc.replace(path, queryValue) : acc
     }, pathname)
 }
 
 /**
  * Removes queries that have already been used in the pathname.
  * @param {string} pathname
- * @param {Record<string, string>} query
- * @returns {Record<string, string>} refined query
+ * @param {Query} query
+ * @returns {Query} refined query
  */
-export function refineQueryWithPathname(pathname: string, query: Record<string, string>): Record<string, string> {
+export function refineQueryWithPathname(pathname: string, query: Query): Query {
     return getDynamicPaths(pathname).reduce((acc, path) => {
         const pathKey = extractPathKey(path)
         const {[pathKey]: _, ...remainingQuery} = acc
@@ -43,4 +47,28 @@ export function refineQueryWithPathname(pathname: string, query: Record<string, 
 const MAX_ASCII_CODE = 127
 export function isASCIICodeChar(char: string) {
     return char.charCodeAt(0) > MAX_ASCII_CODE
+}
+
+function isValidPrimitive(value: unknown): boolean {
+    return ['string', 'number', 'boolean'].includes(typeof value)
+}
+
+/**
+ * Convert queries to array, if they are not of the defined primitive types, they will not be included in the array.
+ * @param {string} pathname
+ * @param {Query} query
+ * @returns {string[][]} refined query
+ */
+export function convertQueryToArray(query: Query): string[][] {
+    return Object.entries(query).flatMap(([key, value]) => {
+        if (isValidPrimitive(value)) {
+            return [[key, String(value)]]
+        }
+
+        if (Array.isArray(value) && value.every(isValidPrimitive)) {
+            return value.map((v) => [key, String(v)])
+        }
+
+        return []
+    })
 }


### PR DESCRIPTION
query 타입을 확장합니다.
- 기존 : Record<string, string>
- 변경 : Record<string, string | number | boolean | (string | number | boolean)[]>

정의된 primitive 타입 (string | number | boolean)이 아니라면 query에 포함되지 않습니다.