### PR TITLE
string 으로 인스턴스 생성시 baseUrl 과 pathname 이 생략된 url 을 지정가능하도록 합니다.

### DIFF
--- a/.changeset/bumpy-pugs-kick.md
+++ b/.changeset/bumpy-pugs-kick.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/nurl": minor
+---
+
+string 으로 인스턴스 생성시 baseUrl 과 pathname 이 생략된 url 을 지정가능하도록 합니다.
+
+PR: [string 으로 인스턴스 생성시 baseUrl 과 pathname 이 생략된 url 을 지정가능하도록 합니다.](https://github.com/NaverPayDev/nurl/pull/55)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,7 +192,7 @@ describe('NURL', () => {
 
                 // Then
                 expect(nurl2.baseUrl).toBe('')
-                expect(nurl2.pathname).toBe('')
+                expect(nurl2.pathname).toBe('/')
                 expect(nurl2.searchParams.get('query')).toBe('value')
             })
         })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -172,6 +172,29 @@ describe('NURL', () => {
                 url.searchParams.set('updatedParam', 'updatedValue')
                 expect(nurl.search).toBe(url.search)
             })
+
+            test('should create an instance even with a string missing baseUrl or pathname', () => {
+                // Given
+                const withoutBaseUrl = '/path?query=value'
+
+                // When
+                const nurl1 = new NURL(withoutBaseUrl)
+
+                // Then
+                expect(nurl1.baseUrl).toBe('')
+                expect(nurl1.pathname).toBe('/path')
+                expect(nurl1.searchParams.get('query')).toBe('value')
+
+                // Given
+                const withoutPathname = '?query=value'
+                // When
+                const nurl2 = new NURL(withoutPathname)
+
+                // Then
+                expect(nurl2.baseUrl).toBe('')
+                expect(nurl2.pathname).toBe('')
+                expect(nurl2.searchParams.get('query')).toBe('value')
+            })
         })
 
         describe('new NURL({ baseUrl, pathname, query })', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -70,20 +70,7 @@ describe('NURL', () => {
             })
 
             test('should handle invalid URLs gracefully', () => {
-                const nurl = new NURL('invalid-url')
-
-                expect(nurl.href).toBe('')
-                expect(nurl.protocol).toBe('')
-                expect(nurl.host).toBe('')
-                expect(nurl.hostname).toBe('')
-                expect(nurl.port).toBe('')
-                expect(nurl.pathname).toBe('')
-                expect(nurl.search).toBe('')
-                expect(nurl.hash).toBe('')
-                expect(nurl.origin).toBe('')
-                expect(nurl.username).toBe('')
-                expect(nurl.password).toBe('')
-                expect(nurl.searchParams.toString()).toBe('')
+                expect(() => new NURL('invalid-url')).toThrowError()
             })
         })
 
@@ -657,10 +644,7 @@ describe('NURL', () => {
             })
 
             test('should handle invalid input gracefully', () => {
-                const url = new NURL('invalid-url')
-                expect(url.href).toBe('')
-                expect(url.protocol).toBe('')
-                expect(url.hostname).toBe('')
+                expect(() => new NURL('invalid-url')).toThrowError()
             })
 
             test('protocol can be changed to a non-special protocol', () => {

--- a/src/nurl.ts
+++ b/src/nurl.ts
@@ -187,8 +187,41 @@ export default class NURL implements URL {
             this._password = url.password
             this._searchParams = url.searchParams
         } catch (error) {
-            // eslint-disable-next-line no-console
-            console.warn(`Can not parse ${value}`, error)
+            const pattern =
+                /^(?:(https?:\/\/)(?:([^:@]+)(?::([^@]+))?@)?((?:[^/:?#]+)(?::(\d+))?)?)?([/][^?#]*)?(\?[^#]*)?(#.*)?$/
+            const match = value.match(pattern)
+            const [
+                ,
+                protocol = '',
+                username = '',
+                password = '',
+                hostname = '',
+                port = '',
+                pathname = '',
+                search = '',
+                hash = '',
+            ] = match || []
+
+            if (!match || (protocol && !hostname && !pathname && !search && !hash)) {
+                // eslint-disable-next-line no-console
+                console.warn(`Can not parse ${value}`, error)
+                return
+            }
+
+            const origin = protocol && hostname ? `${protocol}//${hostname}${port ? `:${port}` : ''}` : ''
+
+            this._href = value
+            this._protocol = protocol
+            this._host = hostname
+            this._hostname = hostname
+            this._port = port
+            this._pathname = value ? pathname || '/' : ''
+            this._search = search
+            this._hash = hash
+            this._origin = origin
+            this._username = username
+            this._password = password
+            this._searchParams = new URLSearchParams(search)
         }
     }
 

--- a/src/nurl.ts
+++ b/src/nurl.ts
@@ -187,41 +187,63 @@ export default class NURL implements URL {
             this._password = url.password
             this._searchParams = url.searchParams
         } catch (error) {
-            const pattern =
-                /^(?:(https?:\/\/)(?:([^:@]+)(?::([^@]+))?@)?((?:[^/:?#]+)(?::(\d+))?)?)?([/][^?#]*)?(\?[^#]*)?(#.*)?$/
-            const match = value.match(pattern)
-            const [
-                ,
-                protocol = '',
-                username = '',
-                password = '',
-                hostname = '',
-                port = '',
-                pathname = '',
-                search = '',
-                hash = '',
-            ] = match || []
+            const urlLike = this.parseStringToURLLike(value)
 
-            if (!match || (protocol && !hostname && !pathname && !search && !hash)) {
+            if (!urlLike) {
                 // eslint-disable-next-line no-console
-                console.warn(`Can not parse ${value}`, error)
-                return
+                console.warn(`Can not parse ${value}`)
+                throw error
             }
 
-            const origin = protocol && hostname ? `${protocol}//${hostname}${port ? `:${port}` : ''}` : ''
+            this._href = urlLike.href
+            this._protocol = urlLike.protocol
+            this._host = urlLike.hostname
+            this._hostname = urlLike.hostname
+            this._port = urlLike.port
+            this._pathname = urlLike.pathname
+            this._search = urlLike.search
+            this._hash = urlLike.hash
+            this._origin = urlLike.origin
+            this._username = urlLike.username
+            this._password = urlLike.password
+            this._searchParams = new URLSearchParams(urlLike.search)
+        }
+    }
 
-            this._href = value
-            this._protocol = protocol
-            this._host = hostname
-            this._hostname = hostname
-            this._port = port
-            this._pathname = value ? pathname || '/' : ''
-            this._search = search
-            this._hash = hash
-            this._origin = origin
-            this._username = username
-            this._password = password
-            this._searchParams = new URLSearchParams(search)
+    private parseStringToURLLike(value: string) {
+        const pattern =
+            /^(?:(https?:\/\/)(?:([^:@]+)(?::([^@]+))?@)?((?:[^/:?#]+)(?::(\d+))?)?)?([/][^?#]*)?(\?[^#]*)?(#.*)?$/
+        const match = value.match(pattern)
+        const [
+            href = value,
+            protocol = '',
+            username = '',
+            password = '',
+            hostname = '',
+            port = '',
+            pathname = '',
+            search = '',
+            hash = '',
+        ] = match || []
+
+        if (!match || (protocol && !hostname && !pathname && !search && !hash)) {
+            return null
+        }
+
+        const origin = protocol && hostname ? `${protocol}//${hostname}${port ? `:${port}` : ''}` : ''
+
+        return {
+            href,
+            protocol,
+            host: hostname,
+            hostname,
+            port,
+            pathname: value ? pathname || '/' : '',
+            search,
+            hash,
+            origin,
+            username,
+            password,
         }
     }
 

--- a/src/nurl.ts
+++ b/src/nurl.ts
@@ -187,7 +187,7 @@ export default class NURL implements URL {
             this._password = url.password
             this._searchParams = url.searchParams
         } catch (error) {
-            const urlLike = this.parseStringToURLLike(value)
+            const urlLike = NURL.parseStringToURLLike(value)
 
             if (!urlLike) {
                 // eslint-disable-next-line no-console
@@ -206,11 +206,11 @@ export default class NURL implements URL {
             this._origin = urlLike.origin
             this._username = urlLike.username
             this._password = urlLike.password
-            this._searchParams = new URLSearchParams(urlLike.search)
+            this._searchParams = urlLike.searchParams
         }
     }
 
-    private parseStringToURLLike(value: string) {
+    static parseStringToURLLike(value: string) {
         const pattern =
             /^(?:(https?:\/\/)(?:([^:@]+)(?::([^@]+))?@)?((?:[^/:?#]+)(?::(\d+))?)?)?([/][^?#]*)?(\?[^#]*)?(#.*)?$/
         const match = value.match(pattern)
@@ -244,6 +244,7 @@ export default class NURL implements URL {
             origin,
             username,
             password,
+            searchParams: new URLSearchParams(search),
         }
     }
 


### PR DESCRIPTION
Closes #54

NURL 생성자에 string 으로 인자 전달시 protocol, hostname 이 포함된 baseUrl 이나 pathname 이 없는 형태의 문자열로도 인스턴스를 생성가능하도록 수정합니다.

### ✅ 다음과 같은 형태도 파싱 가능합니다. (기존 error 케이스)
```ts
const url1 = new NURL("/mypath?foo=bar&bar=baz") // pathname, search

url1.protocol // ''
url1.hostname // ''
url1.origin   // ''
url1.pathname // '/mypath'
url1.search   // '?foo=bar&bar=baz'
url1.searchParams.get('foo') // 'bar'

const url2 = NURL.create("?foo=bar&bar=baz")     // search

url2.protocol // ''
url2.hostname // ''
url2.origin   // ''
url2.pathname // '/'
url2.search   // '?foo=bar&bar=baz'
url2.searchParams.get('foo') // 'bar'
```

