### PR TITLE
Update Query type to use more flexible

### DIFF
--- a/.changeset/honest-dancers-hide.md
+++ b/.changeset/honest-dancers-hide.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/nurl": patch
+---
+
+Update Query type to use more flexible
+
+PR: [Update Query type to use more flexible](https://github.com/NaverPayDev/nurl/pull/60)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
 const DYNAMIC_PATH_COLON_REGEXP = /^:/
 const DYNAMIC_PATH_BRACKETS_REGEXP = /^\[.*\]$/
 
-export type Query = Record<string, string | number | boolean | (string | number | boolean)[]>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Query = Record<string, any>
 
 export function isDynamicPath(path: string) {
     return DYNAMIC_PATH_COLON_REGEXP.test(path) || DYNAMIC_PATH_BRACKETS_REGEXP.test(path)


### PR DESCRIPTION
```typescript
interface IParams {
    a: number 
}
type TParams = {
    a: number
}
const iparams: IParams = { a: 1 };
const tparams: TParams = { a: 1 };

function foo(query: Record<string, number>) {
}

// ✅ 
foo(tparams)

/**
 * ❌
 * Argument of type 'IParams' is not assignable to parameter of type 'Record<string, number>'.
 * Index signature for type 'string' is missing in type 'IParams'.(2345)
 */
foo(iparams)
```

`interface` 로 타입이 선언된 파라미터를 전달할 때 발생하는 타입 오류를 피하기 위해 `any` 로 변경합니다. 
