### PR TITLE
✨ Add release workflows for Canary and RC publishing

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,43 @@
+# Adjust according to your needs
+name: Release Canary
+
+on:
+    issue_comment:
+        types:
+            - created
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+    canary:
+        if: ${{ github.event.issue.pull_request && (github.event.comment.body == 'canary-publish' || github.event.comment.body == '/canary-publish')}}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Get PR branch name
+              id: get_branch
+              run: |
+                  PR=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" ${{ github.event.issue.pull_request.url }})
+                  echo "::set-output name=branch::$(echo $PR | jq -r '.head.ref')"
+
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ steps.get_branch.outputs.branch }}
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'pnpm'
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Canary Publish
+              uses: NaverPayDev/changeset-actions/canary-publish@main
+              with:
+                  github_token: ${{ secrets.ACTION_TOKEN }} # Add user PAT if necessary
+                  npm_tag: canary # Specify the npm tag to use for deployment
+                  npm_token: ${{ secrets.NPM_TOKEN }} # Provide the token required for npm publishing
+                  publish_script: pnpm run release:canary # Script to execute Canary deployment
+                  packages_dir: '.'
+                  excludes: '.turbo,.github' # Files or directories to exclude from change detection
+                  version_template: '{VERSION}-canary.{DATE}-{COMMITID7}'

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -1,0 +1,50 @@
+# Adjust according to your needs
+name: Release RC
+
+on:
+    issue_comment:
+        types:
+            - created
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+    contents: write # to create release
+
+jobs:
+    canary:
+        if: ${{ github.event.issue.pull_request && (github.event.comment.body == 'rc-publish' || github.event.comment.body == '/rc-publish')}}
+        runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        steps:
+            - name: Get PR branch name
+              id: get_branch
+              run: |
+                  PR=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" ${{ github.event.issue.pull_request.url }})
+                  echo "::set-output name=branch::$(echo $PR | jq -r '.head.ref')"
+
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ steps.get_branch.outputs.branch }}
+                  fetch-depth: 0
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: 'pnpm'
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: RC Publish
+              uses: NaverPayDev/changeset-actions/canary-publish@main
+              with:
+                  github_token: ${{ secrets.ACTION_TOKEN }} # Add user PAT if necessary
+                  npm_tag: rc # Specify the npm tag to use for deployment
+                  npm_token: ${{ secrets.NPM_TOKEN }} # Provide the token required for npm publishing
+                  publish_script: pnpm run release:canary # Script to execute Canary deployment
+                  packages_dir: '.'
+                  excludes: '.turbo,.github' # Files or directories to exclude from change detection
+                  version_template: '{VERSION}-rc.{DATE}-{COMMITID7}'
+                  create_release: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
     release:
+        name: Release
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repo
@@ -17,27 +18,27 @@ jobs:
                   token: ${{ secrets.ACTION_TOKEN }}
                   fetch-depth: 0
 
+            - uses: pnpm/action-setup@v4
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: '22.x'
-
-            - name: Enable Corepack
-              run: corepack enable
-
+                  node-version: '22'
+                  cache: 'pnpm'
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
-            - name: Build
-              run: pnpm build
-
-            - name: Create Release Pull Request or Publish to npm
+            - name: Create Release Pull Request
               id: changesets
-              uses: changesets/action@v1
+              uses: NaverPayDev/changeset-actions/publish@main
               with:
-                  title: '🚀 version changed packages'
-                  commit: '📦 bump changed packages version'
-                  publish: pnpm release
+                  github_token: ${{ secrets.ACTION_TOKEN }}
+                  git_username: npayfebot
+                  git_email: npay.fe.bot@navercorp.com
+                  publish_script: pnpm release
+                  pr_title: '🚀 version changed packages'
+                  commit_message: '📦 bump changed packages version'
+                  create_github_release_tag: true
+                  formatting_script: pnpm run markdownlint:fix
+                  npm_token: ${{ secrets.NPM_TOKEN }}
               env:
                   GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "prettier:fix": "prettier --write '**/*.{json,yaml,md,ts,tsx,js,jsx}'",
         "release": "changeset publish",
         "markdownlint": "markdownlint '**/*.md' '#.changeset' '#**/CHANGELOG.md'",
-        "markdownlint:fix": "markdownlint --fix '**/*.md' '#.changeset' '#**/CHANGELOG.md'"
+        "markdownlint:fix": "markdownlint --fix '**/*.md' '#.changeset' '#**/CHANGELOG.md'",
+        "release:canary": "pnpm run build && changeset publish --no-git-tag --directory dist"
     },
     "keywords": [
         "url",


### PR DESCRIPTION
this closes #63 

This pull request introduces new workflows for Canary and RC releases and updates the existing Release workflow to improve consistency and functionality. The changes include adding two new GitHub Actions workflows (`canary.yml` and `rc.yml`) and modifying the `release.yaml` workflow to align with the new workflows' structure and improve release automation.

### New Workflows Added:

* **Canary Workflow (`.github/workflows/canary.yml`):**
  - Introduced a workflow triggered by specific issue comments (`canary-publish` or `/canary-publish`) to handle Canary releases.
  - Includes steps for branch checkout, dependency installation, and Canary publishing using the `NaverPayDev/changeset-actions/canary-publish` action.

* **RC Workflow (`.github/workflows/rc.yml`):**
  - Added a workflow for RC (Release Candidate) releases, triggered by issue comments (`rc-publish` or `/rc-publish`).
  - Supports creating GitHub releases and includes similar steps to the Canary workflow, with adjustments for RC-specific npm tags and release creation.

### Updates to Existing Workflow:

* **Release Workflow (`.github/workflows/release.yaml`):**
  - Updated to use `pnpm/action-setup@v4` and cache dependencies with `pnpm` for improved consistency with the new workflows.
  - Replaced the `changesets/action` with `NaverPayDev/changeset-actions/publish` for publishing and creating release pull requests, adding support for additional configuration options like formatting scripts and GitHub release tags.
  - Minor naming adjustments, such as explicitly naming the release job as "Release".